### PR TITLE
AMPLE RTL bugfixes

### DIFF
--- a/hw/ip/aggregation_engine/include/age_pkg.sv
+++ b/hw/ip/aggregation_engine/include/age_pkg.sv
@@ -21,6 +21,11 @@ typedef struct packed {
     
     logic [MAX_AGC_PER_NODE-1:0] [$clog2(noc_pkg::MAX_MESH_COLS)-1:0] coords_x;
     logic [MAX_AGC_PER_NODE-1:0] [$clog2(noc_pkg::MAX_MESH_ROWS)-1:0] coords_y;
+
+    logic [MAX_AGC_PER_NODE-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0] num_features;
+
+
+
 } AGE_AGM_REQ_t;
 
 typedef struct packed {

--- a/hw/ip/aggregation_engine/rtl/aggregation_core.sv
+++ b/hw/ip/aggregation_engine/rtl/aggregation_core.sv
@@ -35,15 +35,17 @@ module aggregation_core #(
 );
 
 parameter ALLOCATION_PKT_AGGR_FUNC_OFFSET = $clog2(top_pkg::MAX_NODESLOT_COUNT);
+parameter ALLOCATION_PKT_NUM_FEATURES_OFFSET = ALLOCATION_PKT_AGGR_FUNC_OFFSET + $bits(top_pkg::AGGREGATION_FUNCTION_e) ;
 
 parameter EXPECTED_FLITS_PER_PACKET = 1;
 
-typedef enum logic [3:0] {
+typedef enum logic [4:0] {
     AGC_FSM_IDLE,
     AGC_FSM_NODESLOT_ALLOCATION,
     AGC_FSM_WAIT_FEATURE_HEAD,
     AGC_FSM_WAIT_FEATURE_BODY,
     AGC_FSM_UPDATE_ACCS,
+    AGC_FSM_WAIT_UPDATE_ACCS,
     AGC_FSM_WAIT_BUFFER_REQ,
     AGC_FSM_SEND_BUFF_MAN,
     AGC_FSM_WAIT_DRAIN
@@ -118,6 +120,11 @@ logic [$clog2(FEATURE_COUNT/2)-1:0]             sent_flits_counter;
 logic                                           noc_router_waiting;
 
 logic [SCALE_FACTOR_QUEUE_READ_WIDTH-1:0]       scale_factor_q;
+
+
+logic [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0] num_features;
+logic [MESH_NODE_ID_WIDTH - 1 : 0] agc_loc;
+
 
 // ==================================================================================================================================================
 // Instantiations
@@ -202,6 +209,12 @@ always_comb begin
     end
     
     AGC_FSM_UPDATE_ACCS: begin
+        agc_state_n = feature_aggregator_in_feature_ready ? AGC_FSM_WAIT_UPDATE_ACCS
+                    : AGC_FSM_UPDATE_ACCS;
+    end
+
+
+    AGC_FSM_WAIT_UPDATE_ACCS: begin
         agc_state_n = 
                     // Updating last feature accumulator and last packet flag has already been received
                     (received_flits == EXPECTED_FLITS_PER_PACKET[3:0]) && &feature_updated && aggregation_manager_packet_last_q ? AGC_FSM_WAIT_BUFFER_REQ // updating final features
@@ -209,8 +222,9 @@ always_comb begin
                     // Updating last feature accumulator but packets still pending
                     : (received_flits == EXPECTED_FLITS_PER_PACKET[3:0]) && &feature_updated ? AGC_FSM_WAIT_FEATURE_HEAD
 
-                    : AGC_FSM_UPDATE_ACCS;
+                    : AGC_FSM_WAIT_UPDATE_ACCS;
     end
+    
     
     AGC_FSM_WAIT_BUFFER_REQ: begin
         agc_state_n = router_aggregation_core_valid && aggregation_manager_pkt && received_buffer_req_head && tail_packet && correct_pkt_dest ? AGC_FSM_SEND_BUFF_MAN
@@ -239,6 +253,7 @@ logic [noc_pkg::MESH_NODE_ID_WIDTH-1:0] packet_source;
 always_comb begin    
     head_packet = (router_aggregation_core_data.flit_label == noc_pkg::HEAD);
     tail_packet = (router_aggregation_core_data.flit_label == noc_pkg::TAIL);
+
 
     packet_source = router_aggregation_core_data.data.head_data.head_pl[noc_pkg::HEAD_PAYLOAD_SIZE-1 : noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH];    
     packet_source_col = packet_source[MESH_NODE_ID_WIDTH - 1 : MESH_NODE_ID_WIDTH - $clog2(noc_pkg::MAX_MESH_COLS)];
@@ -351,10 +366,23 @@ always_comb begin
                                             : sent_flits_counter == EXPECTED_FLITS_PER_PACKET[$clog2(FEATURE_COUNT/2)-1:0] ? noc_pkg::TAIL
                                             : noc_pkg::BODY;
 
-    aggregation_core_router_data.data.bt_pl = {buffer_manager_pkt_dest_col, buffer_manager_pkt_dest_row,
-                                                X_COORD[$clog2(MAX_MESH_COLS)-1:0], Y_COORD[$clog2(MAX_MESH_ROWS)-1:0], // source node coordinates
-                                                bm_chosen_data };
-end
+    if (sent_flits_counter == '0) begin
+
+        aggregation_core_router_data.data.head_data.x_dest = {buffer_manager_pkt_dest_col};
+        aggregation_core_router_data.data.head_data.y_dest = {buffer_manager_pkt_dest_row};
+
+        agc_loc[MESH_NODE_ID_WIDTH - 1 : MESH_NODE_ID_WIDTH - $clog2(MAX_MESH_COLS)] = X_COORD[$clog2(MAX_MESH_COLS)-1:0]; 
+        agc_loc[$clog2(MAX_MESH_ROWS)-1:0] = Y_COORD[$clog2(MAX_MESH_ROWS)-1:0];
+
+        aggregation_core_router_data.data.head_data.head_pl[noc_pkg::HEAD_PAYLOAD_SIZE-1 : noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH] = agc_loc;
+       
+        aggregation_core_router_data.data.head_data.head_pl[noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH- 1 : noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH - $bits(num_features)] = {num_features};
+
+
+    end else begin
+        aggregation_core_router_data.data.bt_pl = {bm_chosen_data};
+    end
+end 
 
 // Nodeslot allocation
 // --------------------------------------------
@@ -384,6 +412,8 @@ always_ff @(posedge core_clk or negedge resetn) begin
                                                 : router_aggregation_core_data.data.bt_pl [ALLOCATION_PKT_AGGR_FUNC_OFFSET + $bits(top_pkg::AGGREGATION_FUNCTION_e) - 1 : ALLOCATION_PKT_AGGR_FUNC_OFFSET] == 2'd1 ? top_pkg::MEAN
                                                 : router_aggregation_core_data.data.bt_pl [ALLOCATION_PKT_AGGR_FUNC_OFFSET + $bits(top_pkg::AGGREGATION_FUNCTION_e) - 1 : ALLOCATION_PKT_AGGR_FUNC_OFFSET] == 2'd2 ? top_pkg::WEIGHTED_SUM
                                                 : AGGR_FUNC_RESERVED;
+
+        num_features <= router_aggregation_core_data.data.bt_pl [ALLOCATION_PKT_NUM_FEATURES_OFFSET + $bits(top_pkg::MAX_FEATURE_COUNT) - 1 : ALLOCATION_PKT_NUM_FEATURES_OFFSET];  
 
     end
 end

--- a/hw/ip/aggregation_engine/rtl/aggregation_core_allocator.sv
+++ b/hw/ip/aggregation_engine/rtl/aggregation_core_allocator.sv
@@ -74,9 +74,6 @@ if (ALLOCATION_MODE == age_pkg::AGC_ALLOCATION_MODE_STATIC) begin
         agm_req.nsb_req = allocation_req;
         agm_req.required_agcs = layer_config_in_features_count[9:4] + (|layer_config_in_features_count[3:0] ? 1'b1 : '0);
 
-        // Mask of allocated cores, size NUM_CORES = (AGGREGATION_ROWS * AGGREGATION_COLUMNS)
-        // Used later for deallocating AGCs when AGM is finished so they become available for next AGM
-        // Not needed here since allocation is static
         agm_req.allocated_cores = '0;
     end
 
@@ -84,8 +81,17 @@ if (ALLOCATION_MODE == age_pkg::AGC_ALLOCATION_MODE_STATIC) begin
         always_comb begin
             agm_req.coords_x [allocation_slot] = 1'b1 + allocation_slot;
             agm_req.coords_y [allocation_slot] = (allocation_req.nodeslot % NUM_MANAGERS);
+
+            //Final AGC may take less than 16 features
+            if (allocation_slot == (agm_req.required_agcs-1) && |layer_config_in_features_count[3:0]) begin
+                agm_req.num_features [allocation_slot] <= layer_config_in_features_count[3:0];
+            end
+            else begin
+                agm_req.num_features [allocation_slot] <= 16;
+            end
         end
     end
+    
 
 end
 

--- a/hw/ip/aggregation_engine/rtl/aggregation_engine.sv
+++ b/hw/ip/aggregation_engine/rtl/aggregation_engine.sv
@@ -5,7 +5,7 @@ import age_pkg::*;
 
 module aggregation_engine #(
     parameter AXI_ADDR_WIDTH = 32,
-    parameter MESH_MULTIPLPIER = top_pkg::MESH_MULTIPLIER
+    parameter MESH_MULTIPLIER = top_pkg::MESH_MULTIPLIER
 ) (
     input logic core_clk,
     input logic resetn,
@@ -59,6 +59,8 @@ module aggregation_engine #(
     output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       aggregation_buffer_slot_write_enable,
     output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] aggregation_buffer_slot_write_address,
     output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                     aggregation_buffer_slot_write_data,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]                     aggregation_buffer_slot_write_count,
+
     
     input  logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_READ_DEPTH)-1:0]  aggregation_buffer_slot_feature_count,
     input  logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       aggregation_buffer_slot_slot_free,
@@ -121,6 +123,8 @@ logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION
 logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       bm_write_ready;
 logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] bm_write_address;
 logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                     bm_write_data;
+logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]              bm_write_count;
+
 
 logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_ROWS-1:0] buffer_manager_done;
 
@@ -171,7 +175,7 @@ aggregation_engine_regbank_wrapper #(
 for (genvar precision = 0; precision < top_pkg::PRECISION_COUNT; precision++) begin : precision_block
 
     // Multiple mesh blocks to interleave columns of aggregation managers
-    for (genvar mesh = 0; mesh < MESH_MULTIPLPIER; mesh++) begin : mesh_block
+    for (genvar mesh = 0; mesh < MESH_MULTIPLIER; mesh++) begin : mesh_block
 
         aggregation_mesh #(
             .AGGREGATION_ROWS            (AGGREGATION_ROWS),
@@ -209,15 +213,16 @@ for (genvar precision = 0; precision < top_pkg::PRECISION_COUNT; precision++) be
             .scale_factor_queue_out_valid                                  (scale_factor_queue_out_valid              [(precision * AGGREGATION_MANAGERS_PER_PRECISION) + (mesh + 1) * AGGREGATION_ROWS - 1 : (precision * AGGREGATION_MANAGERS_PER_PRECISION) + mesh * AGGREGATION_ROWS]),
             
             // AGE -> Aggregation Buffer
-            .aggregation_buffer_slot_set_node_id_valid                     (bm_set_node_id_valid [precision][mesh]),
-            .aggregation_buffer_slot_set_node_id_ready                     (bm_set_node_id_ready [precision][mesh]),
-            .aggregation_buffer_slot_set_node_id                           (bm_set_node_id       [precision][mesh]),
+            .aggregation_buffer_slot_set_node_id_valid                     (bm_set_node_id_valid                      [precision][mesh]),
+            .aggregation_buffer_slot_set_node_id_ready                     (bm_set_node_id_ready                      [precision][mesh]),
+            .aggregation_buffer_slot_set_node_id                           (bm_set_node_id                            [precision][mesh]),
             
-            .aggregation_buffer_slot_write_enable                          (bm_write_enable      [precision][mesh]),
-            .aggregation_buffer_slot_write_ready                           (bm_write_ready       [precision][mesh]),
-            .aggregation_buffer_slot_write_address                         (bm_write_address     [precision][mesh]),
-            .aggregation_buffer_slot_write_data                            (bm_write_data        [precision][mesh]),
-            
+            .aggregation_buffer_slot_write_enable                          (bm_write_enable                           [precision][mesh]),
+            .aggregation_buffer_slot_write_ready                           (bm_write_ready                            [precision][mesh]),
+            .aggregation_buffer_slot_write_address                         (bm_write_address                          [precision][mesh]),
+            .aggregation_buffer_slot_write_data                            (bm_write_data                             [precision][mesh]),
+            .aggregation_buffer_slot_write_count                           (bm_write_count                            [precision][mesh]),
+
             .aggregation_buffer_slot_feature_count                         (aggregation_buffer_slot_feature_count     [precision]),
             .aggregation_buffer_slot_slot_free                             (aggregation_buffer_slot_slot_free         [precision]),
             
@@ -268,16 +273,17 @@ buffer_manager_arbiter bm_arb_i (
     .input_bm_write_ready        (bm_write_ready),
     .input_bm_write_address      (bm_write_address),
     .input_bm_write_data         (bm_write_data),
+    .input_bm_write_count        (bm_write_count),
 
     // Valid-only interface to buffer slots
-    .slot_set_node_id_valid (aggregation_buffer_slot_set_node_id_valid),
-    .slot_set_node_id       (aggregation_buffer_slot_set_node_id),
+    .slot_set_node_id_valid      (aggregation_buffer_slot_set_node_id_valid),
+    .slot_set_node_id            (aggregation_buffer_slot_set_node_id),
     
-    .slot_write_enable      (aggregation_buffer_slot_write_enable),
-    .slot_write_address     (aggregation_buffer_slot_write_address),
-    .slot_write_data        (aggregation_buffer_slot_write_data),
-    
-    .buffer_manager_done    (buffer_manager_done)
+    .slot_write_enable           (aggregation_buffer_slot_write_enable),
+    .slot_write_address          (aggregation_buffer_slot_write_address),
+    .slot_write_data             (aggregation_buffer_slot_write_data),
+    .slot_write_count            (aggregation_buffer_slot_write_count),
+    .buffer_manager_done         (buffer_manager_done)
 );
 
 // ==================================================================================================================================================

--- a/hw/ip/aggregation_engine/rtl/aggregation_mesh.sv
+++ b/hw/ip/aggregation_engine/rtl/aggregation_mesh.sv
@@ -47,7 +47,8 @@ module aggregation_mesh #(
     input  logic [AGGREGATION_ROWS-1:0]                                                       aggregation_buffer_slot_write_ready,
     output logic [AGGREGATION_ROWS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] aggregation_buffer_slot_write_address,
     output logic [AGGREGATION_ROWS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                     aggregation_buffer_slot_write_data,
-    
+    output logic [AGGREGATION_ROWS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]              aggregation_buffer_slot_write_count,
+
     input  logic [AGGREGATION_ROWS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_READ_DEPTH)-1:0]  aggregation_buffer_slot_feature_count,
     input  logic [AGGREGATION_ROWS-1:0]                                                       aggregation_buffer_slot_slot_free,
 
@@ -292,13 +293,13 @@ for (genvar agm = 0; agm < AGGREGATION_ROWS; agm = agm + 1) begin : agm_block
         // First column of NOC mesh is taken by message channels
         aggregation_manager_router_on    [agm]                     = node_router_on                   [0][agm][0];
         aggregation_manager_router_ready [agm]                     = node_router_ready                [0][agm][0];
-        node_router_valid                [0][agm] = aggregation_manager_router_valid [agm];
-        node_router_data                 [0][agm] = aggregation_manager_router_data  [agm];
+        node_router_valid                [0][agm]                  = aggregation_manager_router_valid [agm];
+        node_router_data                 [0][agm]                  = aggregation_manager_router_data  [agm];
 
-        router_aggregation_manager_valid [agm]                 = router_node_valid                [0][agm];
-        router_aggregation_manager_data  [agm]                 = router_node_data                 [0][agm];
-        router_node_on                   [0][agm][0] = router_aggregation_manager_on    [agm];
-        router_node_ready                [0][agm][0] = router_aggregation_manager_ready [agm];
+        router_aggregation_manager_valid [agm]                     = router_node_valid                [0][agm];
+        router_aggregation_manager_data  [agm]                     = router_node_data                 [0][agm];
+        router_node_on                   [0][agm][0]               = router_aggregation_manager_on    [agm];
+        router_node_ready                [0][agm][0]               = router_aggregation_manager_ready [agm];
     end
 
     assign aggregation_manager_done_nodeslot [agm] = agm_allocation[agm].nodeslot;
@@ -399,6 +400,7 @@ for (genvar bm = 0; bm < AGGREGATION_ROWS; bm++) begin : bm_block
         .bm_buffer_slot_write_ready                    (aggregation_buffer_slot_write_ready  [bm]),
         .bm_buffer_slot_write_address                  (aggregation_buffer_slot_write_address [bm]),
         .bm_buffer_slot_write_data                     (aggregation_buffer_slot_write_data    [bm]),
+        .bm_buffer_slot_write_count                    (aggregation_buffer_slot_write_count   [bm]),
         
         .buffer_slot_bm_feature_count                  (aggregation_buffer_slot_feature_count [bm]),
         .buffer_slot_bm_slot_free                      (aggregation_buffer_slot_slot_free     [bm])

--- a/hw/ip/aggregation_engine/rtl/buffer_manager.sv
+++ b/hw/ip/aggregation_engine/rtl/buffer_manager.sv
@@ -44,11 +44,15 @@ module buffer_manager #(
     input  logic                                                      bm_buffer_slot_write_ready,
     output logic [$clog2(BUFFER_SLOT_WRITE_DEPTH)-1:0]                bm_buffer_slot_write_address,
     output logic [BUFFER_SLOT_WRITE_WIDTH-1:0]                        bm_buffer_slot_write_data,
+    output logic [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]             bm_buffer_slot_write_count,
+
 
     input  logic [$clog2(top_pkg::AGGREGATION_BUFFER_READ_DEPTH)-1:0] buffer_slot_bm_feature_count,
     input  logic                                                      buffer_slot_bm_slot_free
 );
 
+
+//Num features per packet/16 + head flit
 parameter EXPECTED_FLITS_PER_PACKET = 2;
 
 typedef enum logic [3:0] {
@@ -79,7 +83,7 @@ logic [MAX_AGC_PER_NODE-1:0]                               allocated_agcs_oh;
 logic [MAX_AGC_PER_NODE-1:0]                               allocated_agcs;
 logic [MAX_AGC_PER_NODE-1:0]                               agc_done;
 
-flit_t                                                     received_flit;
+flit_t                                                     received_flit_body;
 logic [$clog2(MAX_AGC_PER_NODE)-1:0]                       agc_offset; // offset of the AGC that sent the last received packet flit
 
 logic [$clog2(MAX_MESH_ROWS)-1:0]                          received_packet_source_row;
@@ -88,6 +92,8 @@ logic [$clog2(MAX_MESH_ROWS)-1:0]                          incoming_packet_sourc
 logic [$clog2(MAX_MESH_COLS)-1:0]                          incoming_packet_source_col;
 
 logic [MAX_AGC_PER_NODE-1:0]                               agc_source_oh;
+logic [MAX_AGC_PER_NODE-1:0]                               agc_source_oh_q;
+
 logic [MAX_AGC_PER_NODE-1:0]                               agc_source_oh_early;
 logic [MAX_AGC_PER_NODE-1:0] [3:0]                         flit_counter;
 
@@ -98,6 +104,9 @@ logic [$clog2(MAX_MESH_ROWS)-1:0]                          outgoing_packet_dest_
 logic                                                      noc_router_waiting;
 logic                                                      done_head_sent;
 
+
+logic                                                       valid_agc_body;
+logic                                                       valid_agc_head;
 // ==================================================================================================================================================
 // Instances
 // ==================================================================================================================================================
@@ -135,6 +144,21 @@ always_ff @(posedge core_clk or negedge resetn) begin
     end
 end
 
+
+
+assign valid_agc_body = router_buffer_manager_valid && (router_buffer_manager_data.flit_label == noc_pkg::TAIL);
+assign valid_agc_head = router_buffer_manager_valid && (router_buffer_manager_data.flit_label == noc_pkg::HEAD);
+
+
+always_ff @(posedge core_clk or negedge resetn) begin
+    if (!resetn) begin
+        bm_buffer_slot_write_count <= '0;
+    end else if (valid_agc_head) begin
+        
+        bm_buffer_slot_write_count <= router_buffer_manager_data.data.head_data.head_pl[noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH- 1 : noc_pkg::HEAD_PAYLOAD_SIZE-MESH_NODE_ID_WIDTH - $bits(bm_buffer_slot_write_count)];
+    end
+end
+
 always_comb begin
     bm_state_n = bm_state;
 
@@ -149,7 +173,7 @@ always_comb begin
         end
 
         BM_FSM_WAIT_FEATURES: begin
-            bm_state_n = router_buffer_manager_valid ? BM_FSM_WRITE : BM_FSM_WAIT_FEATURES;
+            bm_state_n = /* !(&agc_done) &&*/ valid_agc_body ? BM_FSM_WRITE : BM_FSM_WAIT_FEATURES;
         end
 
         BM_FSM_WRITE: begin
@@ -208,8 +232,6 @@ assign buffer_manager_done = (bm_state == BM_FSM_WAIT_TRANSFORMATION) && (bm_sta
 // -------------------------------------------------------------------------------------
 
 always_comb begin
-    {received_packet_source_col, received_packet_source_row} = noc_pkg::decode_packet_source(received_flit);
-
     // Decode packets arriving during handshake
     {incoming_packet_source_col, incoming_packet_source_row} = noc_pkg::decode_packet_source(router_buffer_manager_data);
 end
@@ -224,12 +246,14 @@ end
 
 always_ff @(posedge core_clk or negedge resetn) begin
     if (!resetn) begin
-        received_flit <= '0;
+        received_flit_body <= '0;
     
-    end else if (router_buffer_manager_on && router_buffer_manager_valid && router_buffer_manager_ready) begin
-        received_flit <= router_buffer_manager_data;
+    end else if (router_buffer_manager_on && router_buffer_manager_valid && router_buffer_manager_ready && valid_agc_body) begin
+        received_flit_body <= router_buffer_manager_data;
     end
 end
+
+
 
 // Flit counter for each AGC allocated to the current nodeslot
 // -------------------------------------------------------------------------------------
@@ -237,11 +261,18 @@ end
 for (genvar agc_source = 0; agc_source < MAX_AGC_PER_NODE; agc_source++) begin
 
     // One hot mask indicating which AGC in the allocation list is the source of the current packet
-    assign agc_source_oh[agc_source] = (allocated_agcs_x_coords_q[agc_source] == received_packet_source_col)
-                                        && (allocated_agcs_y_coords_q[agc_source] == received_packet_source_row);
+    always_ff @(posedge core_clk or negedge resetn) begin
+        if (!resetn) begin
+            agc_source_oh_q[agc_source] <= 0;
+        end else begin
+            agc_source_oh_q[agc_source] <= agc_source_oh[agc_source];
+        end
+    end
     
-    assign agc_source_oh_early[agc_source] = (allocated_agcs_x_coords_q[agc_source] == incoming_packet_source_col)
-                                        && (allocated_agcs_y_coords_q[agc_source] == incoming_packet_source_row);
+    assign agc_source_oh[agc_source] = (valid_agc_head && router_buffer_manager_on && router_buffer_manager_valid && router_buffer_manager_ready) ? (allocated_agcs_x_coords_q[agc_source] == incoming_packet_source_col)
+                                         && (allocated_agcs_y_coords_q[agc_source] == incoming_packet_source_row) && allocated_agcs[agc_source] : agc_source_oh_q[agc_source];
+    
+
     
     always_ff @(posedge core_clk or negedge resetn) begin
         if (!resetn) begin
@@ -254,7 +285,7 @@ for (genvar agc_source = 0; agc_source < MAX_AGC_PER_NODE; agc_source++) begin
         // Accepting the feature flit from an AGC
         end else if (router_buffer_manager_on && router_buffer_manager_valid && router_buffer_manager_ready) begin
             // Read AGC source combinatorially from incoming packet (not registered yet)
-            flit_counter[agc_source] <= agc_source_oh_early[agc_source] ? flit_counter[agc_source] + 1'b1 : flit_counter[agc_source];
+            flit_counter[agc_source] <= agc_source_oh[agc_source] ? flit_counter[agc_source] + 1'b1 : flit_counter[agc_source];
         end
     end
 
@@ -265,9 +296,9 @@ end
 // -------------------------------------------------------------------------------------
 
 always_comb begin
-    bm_buffer_slot_write_enable = (bm_state == BM_FSM_WRITE) && !(&agc_done); // at least one agc isn't done yet
-    bm_buffer_slot_write_address = agc_offset;
-    bm_buffer_slot_write_data = received_flit.data.bt_pl;
+    bm_buffer_slot_write_enable = (bm_state == BM_FSM_WRITE)/* && !(&agc_done)*/; // at least one agc isn't done yet
+    bm_buffer_slot_write_address = agc_offset; 
+    bm_buffer_slot_write_data = received_flit_body.data.bt_pl;
 end
 
 // Send done packet to Aggregation Manager

--- a/hw/ip/aggregation_engine/rtl/buffer_manager_arbiter.sv
+++ b/hw/ip/aggregation_engine/rtl/buffer_manager_arbiter.sv
@@ -16,17 +16,19 @@ module buffer_manager_arbiter #(
     output logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       input_bm_write_ready,
     input  logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] input_bm_write_address,
     input  logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                     input_bm_write_data,
+    input  logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]              input_bm_write_count,
 
     // AGGREGATION BUFFER SLOTS == AGGREGATION ROWS
     // Valid-only interface to buffer slots
-    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       slot_set_node_id_valid,
-    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [NODE_ID_WIDTH-1:0]                                   slot_set_node_id,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                                                      slot_set_node_id_valid,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [NODE_ID_WIDTH-1:0]                                                                  slot_set_node_id,
 
-    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       slot_write_enable,
-    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] slot_write_address,
-    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                     slot_write_data,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                                                      slot_write_enable,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH)-1:0]                                slot_write_address,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [noc_pkg::PAYLOAD_DATA_WIDTH-1:0]                                                    slot_write_data,
+    output logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]                                             slot_write_count,
 
-    input  logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] buffer_manager_done
+    input  logic [top_pkg::PRECISION_COUNT-1:0] [top_pkg::MESH_MULTIPLIER-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                                       buffer_manager_done
 );
 
 // ==================================================================================================================================================
@@ -106,6 +108,8 @@ for (genvar precision = 0; precision < top_pkg::PRECISION_COUNT; precision++) be
             slot_write_enable [precision][slot]  = input_bm_write_enable  [precision] [granted_bm_bin_q [precision] [slot]] [slot];
             slot_write_address [precision][slot] = input_bm_write_address [precision] [granted_bm_bin_q [precision] [slot]] [slot];
             slot_write_data [precision][slot]    = input_bm_write_data    [precision] [granted_bm_bin_q [precision] [slot]] [slot];
+            slot_write_count [precision][slot]   = input_bm_write_count   [precision] [granted_bm_bin_q [precision] [slot]] [slot];
+
         end
     end : slot_block_logic
 end : precision_block_logic

--- a/hw/ip/aggregation_engine/rtl/feature_aggregator.sv
+++ b/hw/ip/aggregation_engine/rtl/feature_aggregator.sv
@@ -56,20 +56,35 @@ logic [FLOAT_WIDTH-1:0]                       accumulator_float;
 
 if (PRECISION == top_pkg::FLOAT_32) begin
 
-`ifdef SIMULATION
+`ifdef SIMULATION_QUICK
     assign scaled_feature_valid_comb = in_feature_valid && in_feature_ready;
     assign scaled_feature_comb = in_feature;
 `else
-    fp_mult scale_factor_mult (
-        .s_axis_a_tvalid      (in_feature_valid && in_feature_ready),
-        .s_axis_a_tdata       (scale_factor),
+    //Fix 
+    assign scaled_feature_valid_comb = in_feature_valid && in_feature_ready;
+    assign scaled_feature_comb = in_feature;
+    // // fp_mult scale_factor_mult ( //Incorrect ports?
+    // //     .s_axis_a_tvalid      (in_feature_valid && in_feature_ready),
+    // //     .s_axis_a_tdata       (scale_factor),
         
-        .s_axis_b_tvalid      (in_feature_valid && in_feature_ready),
-        .s_axis_b_tdata       (in_feature),
+    // //     .s_axis_b_tvalid      (in_feature_valid && in_feature_ready),
+    // //     .s_axis_b_tdata       (in_feature),
         
-        .m_axis_result_tvalid (scaled_feature_valid_comb),
-        .m_axis_result_tdata  (scaled_feature_comb) 
-    );
+    // //     .m_axis_result_tvalid (scaled_feature_valid_comb),
+    // //     .m_axis_result_tdata  (scaled_feature_comb) 
+    // // );
+    // fp_mult scale_factor_mult (
+    //     //   .s_axis_a_tvalid(in_valid && in_ready),
+    //     .in1(scale_factor),
+
+    //     //   .s_axis_b_tvalid(in_valid && in_ready),
+    //     .in2(in_feature),
+        
+    //     //   .m_axis_result_tvalid(fp_mult_result_valid_comb),
+    //     .res(scaled_feature_comb)
+    // );
+    // assign scaled_feature_valid_comb = in_feature_valid && in_feature_ready;
+
 `endif
 
 end else begin
@@ -170,7 +185,6 @@ always_ff @(posedge core_clk or negedge resetn) begin
         accumulator                <= '0;
         
     end else if (feature_updated) begin
-        feature_accumulation_count <= feature_accumulation_count + 1'b1;
 
         if (feature_accumulation_count == '0) begin
             accumulator <= passthrough_aggregator_out_feature;
@@ -186,6 +200,9 @@ always_ff @(posedge core_clk or negedge resetn) begin
 
             endcase
         end
+
+        feature_accumulation_count <= feature_accumulation_count + 1'b1;
+
     end
 end
 

--- a/hw/ip/node_scoreboard/rtl/node_scoreboard.sv
+++ b/hw/ip/node_scoreboard/rtl/node_scoreboard.sv
@@ -126,6 +126,10 @@ logic layer_config_weights_address_lsb_strobe;                          // strob
 logic [3:0] [31:0] layer_config_weights_address_lsb_lsb;                      // value of field 'LAYER_CONFIG_WEIGHTS_ADDRESS_LSB.LSB'
 logic layer_config_weights_address_msb_strobe;                          // strobe signal for register 'LAYER_CONFIG_WEIGHTS_ADDRESS_MSB' (pulsed when the register is written from the bus)
 logic [3:0] [1:0] layer_config_weights_address_msb_msb;                       // value of field 'LAYER_CONFIG_WEIGHTS_ADDRESS_MSB.MSB'
+logic layer_config_aggregate_enable_strobe;
+logic [0:0] layer_config_aggregate_enable_value;
+
+
 
 // Nodeslots
 
@@ -263,6 +267,9 @@ node_scoreboard_regbank_regs node_scoreboard_regbank_i (
     .layer_config_adjacency_list_address_msb_msb,
     .layer_config_weights_address_lsb_lsb,
     .layer_config_weights_address_msb_msb,
+
+    .layer_config_aggregate_enable_value,
+
 
     .ctrl_fetch_layer_weights_fetch,
     .ctrl_fetch_layer_weights_done_done,
@@ -616,10 +623,9 @@ always_comb begin : nsb_prefetcher_req_logic
                                         : top_pkg::FETCH_RESERVED;
 
     nsb_prefetcher_req.nodeslot      = prefetcher_arbiter_grant_bin;
-    
-    nsb_prefetcher_req.start_address = nsb_prefetcher_req.req_opcode == top_pkg::WEIGHTS ? {layer_config_weights_address_msb_msb [ctrl_fetch_layer_weights_precision_value], layer_config_weights_address_lsb_lsb [ctrl_fetch_layer_weights_precision_value]}
-                                    : nsb_prefetcher_req.req_opcode == top_pkg::ADJACENCY_LIST ? {layer_config_adjacency_list_address_msb_msb[prefetcher_arbiter_grant_bin], layer_config_adjacency_list_address_lsb_lsb + nsb_nodeslot_node_id_id[prefetcher_arbiter_grant_bin] * 64}
-                                    : nsb_prefetcher_req.req_opcode == top_pkg::SCALE_FACTOR ? {layer_config_scale_factors_address_msb_value[prefetcher_arbiter_grant_bin], layer_config_scale_factors_address_lsb_value[prefetcher_arbiter_grant_bin] + nsb_nodeslot_node_id_id[prefetcher_arbiter_grant_bin] * 64}
+    nsb_prefetcher_req.start_address = nsb_prefetcher_req.req_opcode == top_pkg::WEIGHTS ? {layer_config_weights_address_msb_msb /*[ctrl_fetch_layer_weights_precision_value[1]]*/, layer_config_weights_address_lsb_lsb [ctrl_fetch_layer_weights_precision_value]}
+                                    : nsb_prefetcher_req.req_opcode == top_pkg::ADJACENCY_LIST ? {layer_config_adjacency_list_address_msb_msb/*[prefetcher_arbiter_grant_bin]*/, layer_config_adjacency_list_address_lsb_lsb + nsb_nodeslot_node_id_id[prefetcher_arbiter_grant_bin] * 64}
+                                    : nsb_prefetcher_req.req_opcode == top_pkg::SCALE_FACTOR ? {layer_config_scale_factors_address_msb_value/*[prefetcher_arbiter_grant_bin]*/, layer_config_scale_factors_address_lsb_value[prefetcher_arbiter_grant_bin] + nsb_nodeslot_node_id_id[prefetcher_arbiter_grant_bin] * 64}
                                     : '0;
     
 

--- a/hw/ip/prefetcher/include/prefetcher_pkg.sv
+++ b/hw/ip/prefetcher/include/prefetcher_pkg.sv
@@ -36,4 +36,17 @@ typedef enum logic [2:0] {
     MSG_DONE = 4
 } FETCH_TAG_MESSAGE_FETCH_FSM_e;
 
+function logic [MESSAGE_QUEUE_WIDTH-1:0] reverse_float_order(input logic [MESSAGE_QUEUE_WIDTH-1:0] msg_queue_write_data);
+    localparam int NUM_FLOATS = MESSAGE_QUEUE_WIDTH / 32;
+
+    logic [MESSAGE_QUEUE_WIDTH-1:0] reversed_data;
+
+    // Loop to reverse the order of 32-bit floats
+    for (int i = 0; i < NUM_FLOATS; i++) begin
+        reversed_data[(NUM_FLOATS-i-1)*32 +: 32] = msg_queue_write_data[i*32 +: 32];
+    end
+
+    return reversed_data;
+endfunction
+
 endpackage

--- a/hw/ip/prefetcher/rtl/prefetcher_feature_bank.sv
+++ b/hw/ip/prefetcher/rtl/prefetcher_feature_bank.sv
@@ -104,7 +104,7 @@ logic [FETCH_TAG_COUNT-1:0]                                        fetch_tag_res
 logic [$clog2(FETCH_TAG_COUNT)-1:0]                                fetch_tag_resp_arb_bin;
 
 // Adjacency Read Master request arbitration
-logic [HBM_BANKS - 1 : 0] [FETCH_TAG_COUNT-1:0]         chosen_fetch_tag_rm_req;
+logic [HBM_BANKS - 1 : 0] [FETCH_TAG_COUNT-1:0]         chosen_fetch_tag_rm_req; //FETCH_TAGS_PER_BANK could use this bitwidth and multiplex each HBM to its fetch tag
 logic [HBM_BANKS - 1 : 0] [$clog2(FETCH_TAG_COUNT)-1:0] chosen_fetch_tag_rm_req_bin;
 logic [HBM_BANKS - 1 : 0] [$clog2(FETCH_TAG_COUNT)-1:0] chosen_fetch_tag_rm_req_bin_q;
 

--- a/hw/ip/prefetcher/rtl/prefetcher_fetch_tag.sv
+++ b/hw/ip/prefetcher/rtl/prefetcher_fetch_tag.sv
@@ -158,6 +158,8 @@ ultraram_fifo #(
     .in_data        (adj_queue_write_data),
     .pop            (pop_adj_queue),
     .reset_read_ptr ('0),
+    .reset_write_ptr ('0),
+
     .out_valid      (adj_queue_head_valid),
     .out_data       (adj_queue_head),
     .count          (adj_queue_count),
@@ -223,6 +225,8 @@ ultraram_fifo #(
     
     .pop            (pop_message_queue),
     .reset_read_ptr ('0),
+    .reset_write_ptr ('0),
+
     .out_valid      (message_queue_head_valid),
     .out_data       (message_queue_head),
     
@@ -389,10 +393,11 @@ always_comb begin
     fetch_tag_msg_rm_resp_ready = (message_fetch_state == prefetcher_pkg::MSG_STORE) || scale_factor_read_master_resp_ready;
 
     push_message_queue   = (message_fetch_state == prefetcher_pkg::MSG_STORE) && accepting_msg_fetch_resp;
-    msg_queue_write_data = fetch_tag_msg_rm_resp_data;
+    msg_queue_write_data = reverse_float_order(fetch_tag_msg_rm_resp_data); //Temporary - fix order in SDK memory mapper
     
     pop_adj_queue = (message_fetch_state == prefetcher_pkg::MSG_FETCH) && accepting_message_fetch_req;
 end
+
 
 always_ff @(posedge core_clk or negedge resetn) begin
     if (!resetn) begin
@@ -480,7 +485,8 @@ always_comb begin
     // message_channel_resp.last = (message_queue_count == {{($clog2(MESSAGE_QUEUE_DEPTH)-1){1'b0}}, 1'b1});
     
     // When message queue count reaches feature count / 16 (rounded up), sending last neighbour's features
-    message_channel_resp.last_neighbour = message_queue_count <= ({allocated_feature_count[$clog2(MAX_FEATURE_COUNT)-1:4], 4'd0} + (|allocated_feature_count[3:0] ? 1'b1 : 1'b0));
+    //
+    message_channel_resp.last_neighbour = message_queue_count <=  ({4'd0,allocated_feature_count[$clog2(MAX_FEATURE_COUNT)-1:4]} + (|allocated_feature_count[3:0] ? 1'b1 : 1'b0));
 
     // Sending last feature when message queue count == 1
     message_channel_resp.last_feature = (message_queue_count[$clog2(MESSAGE_QUEUE_DEPTH)-1:1] == '0) && message_queue_count[0];
@@ -512,6 +518,8 @@ always_ff @(posedge core_clk or negedge resetn) begin
         // allocation payloads remain written
     end
 end
+
+
 
 
 endmodule

--- a/hw/ip/prefetcher/rtl/prefetcher_weight_bank.sv
+++ b/hw/ip/prefetcher/rtl/prefetcher_weight_bank.sv
@@ -105,7 +105,11 @@ logic [FEATURE_COUNT-1:0]                      row_pop_shift;
 logic [$clog2(FEATURE_COUNT):0]                row_counter;
 
 logic reset_weights;
+logic empty_weights; //When next layer is ready to fetch weights, reset wr_ptr of all row FIFOs
+logic done_resp;
 
+
+assign empty_weights = (weight_bank_state == WEIGHT_BANK_FSM_WEIGHTS_WAITING) && (weight_bank_state_n == WEIGHT_BANK_FSM_FETCH_REQ);
 // ==================================================================================================================================================
 // Instances
 // ==================================================================================================================================================
@@ -118,17 +122,18 @@ for (genvar row = 0; row < FEATURE_COUNT; row++) begin
         .core_clk,
         .resetn,
         
-        .push       (row_fifo_push      [row]),
-        .in_data    (row_fifo_in_data),
+        .push                   (row_fifo_push      [row]),
+        .in_data                (row_fifo_in_data),
         
-        .pop            (row_fifo_pop       [row]),
-        .reset_read_ptr (reset_weights),
-        .out_valid  (row_fifo_out_valid [row]),
-        .out_data   (row_fifo_out_data  [row]),
+        .pop                    (row_fifo_pop       [row]),
+        .reset_read_ptr         (reset_weights),
+        .reset_write_ptr        (empty_weights),
+        .out_valid              (row_fifo_out_valid [row]),
+        .out_data               (row_fifo_out_data  [row]),
         
-        .count      (row_fifo_count     [row]),
-        .empty      (row_fifo_empty     [row]),
-        .full       (row_fifo_full      [row])
+        .count                  (row_fifo_count     [row]),
+        .empty                  (row_fifo_empty     [row]),
+        .full                   (row_fifo_full      [row])
     );
 
     assign row_fifo_push      [row] = (weight_bank_state == WEIGHT_BANK_FSM_WRITE) & (row == (rows_fetched - 1));
@@ -350,16 +355,31 @@ always_ff @(posedge core_clk or negedge resetn) begin
     end
 end
 
+
+always_ff @(posedge core_clk or negedge resetn) begin
+    if (!resetn) begin
+        done_resp <= '0;
+    end
+    else if (reset_weights) begin 
+        done_resp<= '0;
+    end
+    else if (weight_bank_state == WEIGHT_BANK_FSM_DUMP_WEIGHTS) begin
+        done_resp <= weight_channel_resp.done;
+    end
+end
+
+
+
 always_comb begin
     // Issue weight channel response when new data is available on all row FIFOs following a pop
-    weight_channel_resp_valid = (weight_bank_state == WEIGHT_BANK_FSM_DUMP_WEIGHTS) && (&row_fifo_out_valid) && |row_pop_shift;
+    weight_channel_resp_valid      = ((weight_bank_state == WEIGHT_BANK_FSM_DUMP_WEIGHTS) && (&row_fifo_out_valid) && |row_pop_shift)||done_resp ;
 
     weight_channel_resp.data       = row_fifo_out_data;
     weight_channel_resp.valid_mask = row_pop_shift & ~row_fifo_empty;
     
     weight_channel_resp.done       = (weight_channel_resp.valid_mask == '0);
     
-    accepting_weight_channel_resp = (weight_channel_resp_valid && weight_channel_resp_ready);
+    accepting_weight_channel_resp  = (weight_channel_resp_valid && weight_channel_resp_ready);
 end
 
 // When finished dumping weights, reset read pointer so the same weights can be used for the next FTE pass

--- a/hw/ip/top/rtl/top.sv
+++ b/hw/ip/top/rtl/top.sv
@@ -261,6 +261,8 @@ logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [NODE_ID_WID
 logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0]                                              aggregation_buffer_write_enable;
 logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(AGGREGATION_BUFFER_WRITE_DEPTH)-1:0] aggregation_buffer_write_address;
 logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [AGGREGATION_BUFFER_WRITE_WIDTH-1:0]         aggregation_buffer_write_data;
+logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(top_pkg::MAX_FEATURE_COUNT)-1:0]     aggregation_buffer_write_count;
+
 logic [top_pkg::PRECISION_COUNT-1:0] [AGGREGATION_BUFFER_SLOTS-1:0] [$clog2(AGGREGATION_BUFFER_READ_DEPTH)-1:0]  aggregation_buffer_feature_count;
 
 // FTE -> Aggregation Buffer Interface
@@ -666,6 +668,7 @@ aggregation_engine aggregation_engine_i (
     .aggregation_buffer_slot_write_enable         (aggregation_buffer_write_enable),
     .aggregation_buffer_slot_write_address        (aggregation_buffer_write_address),
     .aggregation_buffer_slot_write_data           (aggregation_buffer_write_data),
+    .aggregation_buffer_slot_write_count          (aggregation_buffer_write_count),
 
     .aggregation_buffer_slot_feature_count        (aggregation_buffer_feature_count),
     .aggregation_buffer_slot_slot_free            (aggregation_buffer_slot_free),
@@ -679,35 +682,41 @@ aggregation_engine aggregation_engine_i (
 // Aggregation Buffer
 // ====================================================================================
 
-for (genvar precision = top_pkg::FLOAT_32; precision < top_pkg::PRECISION_COUNT; precision++) begin
 
-    hybrid_buffer #(
-        .NUM_SLOTS   (top_pkg::AGGREGATION_BUFFER_SLOTS),
-        .WRITE_WIDTH (top_pkg::AGGREGATION_BUFFER_WRITE_WIDTH),
-        .WRITE_DEPTH (top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH),
-        .READ_WIDTH  (top_pkg::AGGREGATION_BUFFER_READ_WIDTH),
-        .READ_DEPTH  (top_pkg::AGGREGATION_BUFFER_READ_DEPTH)
-    ) aggregation_buffer_i (
-        .core_clk           (sys_clk),
-        .resetn             (!sys_rst),
+generate begin:AGGREGATION_BUFFER
 
-        .set_node_id_valid  (aggregation_buffer_set_node_id_valid [precision]),
-        .set_node_id        (aggregation_buffer_set_node_id       [precision]),
-        .slot_node_id       (aggregation_buffer_node_id           [precision]),
+    for (genvar precision = top_pkg::FLOAT_32; precision < top_pkg::PRECISION_COUNT; precision++) begin: AGGREGATION_BUFFER_i
 
-        .write_enable       (aggregation_buffer_write_enable    [precision]),
-        .write_address      (aggregation_buffer_write_address   [precision]),
-        .write_data         (aggregation_buffer_write_data      [precision]),
-        .feature_count      (aggregation_buffer_feature_count   [precision]),
+        hybrid_buffer #(
+            .NUM_SLOTS   (top_pkg::AGGREGATION_BUFFER_SLOTS),
+            .WRITE_WIDTH (top_pkg::AGGREGATION_BUFFER_WRITE_WIDTH),
+            .WRITE_DEPTH (top_pkg::AGGREGATION_BUFFER_WRITE_DEPTH),
+            .READ_WIDTH  (top_pkg::AGGREGATION_BUFFER_READ_WIDTH),
+            .READ_DEPTH  (top_pkg::AGGREGATION_BUFFER_READ_DEPTH)
+        ) aggregation_buffer_i (
+            .core_clk           (sys_clk),
+            .resetn             (!sys_rst),
 
-        .pop                (aggregation_buffer_pop               [precision]),
-        .out_feature        (aggregation_buffer_out_feature       [precision]),
-        .out_feature_valid  (aggregation_buffer_out_feature_valid [precision]),
-        .slot_free          (aggregation_buffer_slot_free         [precision])
+            .set_node_id_valid  (aggregation_buffer_set_node_id_valid [precision]),
+            .set_node_id        (aggregation_buffer_set_node_id       [precision]),
+            .slot_node_id       (aggregation_buffer_node_id           [precision]),
 
-    );
+            .write_enable       (aggregation_buffer_write_enable    [precision]),
+            .write_address      (aggregation_buffer_write_address   [precision]),
+            .write_data         (aggregation_buffer_write_data      [precision]),
+            .write_count        (aggregation_buffer_write_count      [precision]),
+
+            .feature_count      (aggregation_buffer_feature_count   [precision]),
+
+            .pop                (aggregation_buffer_pop               [precision]),
+            .out_feature        (aggregation_buffer_out_feature       [precision]),
+            .out_feature_valid  (aggregation_buffer_out_feature_valid [precision]),
+            .slot_free          (aggregation_buffer_slot_free         [precision])
+
+        );
+    end
 end
-
+endgenerate
 
 // ====================================================================================
 // Transformation Engine

--- a/hw/ip/transformation_engine/rtl/feature_transformation_core.sv
+++ b/hw/ip/transformation_engine/rtl/feature_transformation_core.sv
@@ -1,6 +1,9 @@
 
 import top_pkg::*;
 
+//Temporary fix to reverse feature order in writeback
+//TODO Change feature writeback order to be in order of systolic modules - remove this import
+import prefetcher_pkg::*;
 module feature_transformation_core #(
     parameter PRECISION = top_pkg::FLOAT_32,
     parameter FLOAT_WIDTH = 32,
@@ -52,6 +55,7 @@ module feature_transformation_core #(
     input  logic                                                                                      axi_write_master_pop,
     output logic                                                                                      axi_write_master_data_valid,
     output logic [511:0]                                                                              axi_write_master_data,
+    output logic [511:0]                                                                               axi_write_master_data_unreversed, //Temp
 
     input  logic                                                                                      axi_write_master_resp_valid,
     output logic                                                                                      axi_write_master_resp_ready,
@@ -61,15 +65,15 @@ module feature_transformation_core #(
     input  logic [9:0]                                                                                layer_config_out_features_count,
     input  logic [1:0]                                                                                layer_config_out_features_address_msb_value,
     input  logic [31:0]                                                                               layer_config_out_features_address_lsb_value,
-    input  logic [31:0]                                                                               layer_config_bias_value,
+    input  logic [31:0]                                                                               layer_config_bias_value, //needs be paramterised to sytolic module count
     input  logic [1:0]                                                                                layer_config_activation_function_value,
     input  logic [31:0]                                                                               layer_config_leaky_relu_alpha_value,
     input  logic [0:0]                                                                                ctrl_buffering_enable_value,
     input  logic [0:0]                                                                                ctrl_writeback_enable_value
 );
 
-parameter SYS_MODULES_PER_BEAT = 512 / (MATRIX_N * FLOAT_WIDTH);
-parameter MAX_WRITEBACK_BEATS_PER_NODESLOT = SYSTOLIC_MODULE_COUNT / SYS_MODULES_PER_BEAT;
+parameter SYS_MODULES_PER_BEAT = 512 / (FLOAT_WIDTH);
+parameter MAX_WRITEBACK_BEATS_PER_NODESLOT = (SYSTOLIC_MODULE_COUNT*MATRIX_N) / SYS_MODULES_PER_BEAT;
 
 typedef enum logic [3:0] {
     FTE_FSM_IDLE, FTE_FSM_REQ_WC, FTE_FSM_MULT_SLOW, FTE_FSM_MULT_FAST, FTE_FSM_BIAS, FTE_FSM_ACTIVATION, FTE_FSM_BUFFER, FTE_FSM_WRITEBACK_REQ, FTE_FSM_WRITEBACK_RESP, FTE_FSM_SHIFT, FTE_FSM_NSB_RESP
@@ -81,6 +85,9 @@ typedef enum logic [3:0] {
 
 FTE_FSM_e fte_state, fte_state_n;
 logic last_weight_resp_received;
+
+logic [MATRIX_N:0] valid_row;
+
 
 // NSB requests
 logic [top_pkg::MAX_NODESLOT_COUNT-1:0]         nsb_req_nodeslots_q;
@@ -105,6 +112,7 @@ logic [MAX_FEATURE_COUNT-1:0] [DATA_WIDTH-1:0]                                  
 logic [SYSTOLIC_MODULE_COUNT-1:0]                                               sys_module_flush_done;
 
 logic [SYSTOLIC_MODULE_COUNT-1:0] [MATRIX_N:0] [MATRIX_N-1:0] [DATA_WIDTH-1:0]  sys_module_pe_acc;
+logic  [MATRIX_N*SYSTOLIC_MODULE_COUNT-1:0] [DATA_WIDTH-1:0]                    sys_module_pe_acc_row0;
 
 logic [SYSTOLIC_MODULE_COUNT-1:0]                                               shift_sys_module;
 logic                                                                           bias_valid;
@@ -145,11 +153,21 @@ logic bias_applied, activation_applied;
 // Systolic Modules
 // --------------------------------------------------------------------------------
 
+//Concat top row so that axi_write_data can interate over it and not worry about meshes
+for (genvar j = 0; j < SYSTOLIC_MODULE_COUNT*MATRIX_N ; j++) begin
+    always_comb begin
+        sys_module_down_in_valid[j] = weight_channel_resp_valid & weight_channel_resp.valid_mask[j];
+        sys_module_down_in[j] = sys_module_down_in_valid[j] ? weight_channel_resp.data[j] : 1'b0; // Is this needed can use in PE
+    end
+end 
+
+
 for (genvar sys_module = 0; sys_module < SYSTOLIC_MODULE_COUNT; sys_module++) begin : sys_modules
     // Driving from weight channel
     always_comb begin
-        sys_module_down_in_valid [sys_module*MATRIX_N + (MATRIX_N-1) : sys_module*MATRIX_N] = {MATRIX_N{weight_channel_resp_valid}} & weight_channel_resp.valid_mask[sys_module*MATRIX_N + (MATRIX_N-1) : sys_module*MATRIX_N];
-        sys_module_down_in       [sys_module*MATRIX_N + (MATRIX_N-1) : sys_module*MATRIX_N] = weight_channel_resp.data[sys_module*MATRIX_N + (MATRIX_N-1) : sys_module*MATRIX_N];
+        sys_module_pe_acc_row0 [sys_module*MATRIX_N + (MATRIX_N-1) : sys_module*MATRIX_N]  = sys_module_pe_acc [sys_module][0];
+        shift_sys_module[sys_module] = (fte_state == FTE_FSM_SHIFT)||(fte_state_n == FTE_FSM_IDLE); //Shift out last row when next state is IDLE
+ 
     end
     
     systolic_module #(
@@ -278,7 +296,7 @@ always_comb begin
         end
 
         FTE_FSM_WRITEBACK_REQ: begin
-            fte_state_n = axi_write_master_req_ready ? FTE_FSM_WRITEBACK_RESP : FTE_FSM_WRITEBACK_REQ;
+            fte_state_n = (!valid_row[0]) ?  FTE_FSM_SHIFT : axi_write_master_req_ready ? FTE_FSM_WRITEBACK_RESP : FTE_FSM_WRITEBACK_REQ;
         end
 
         FTE_FSM_WRITEBACK_RESP: begin
@@ -286,8 +304,8 @@ always_comb begin
                         // Sending last beat for last nodeslot
                         (nodeslots_to_writeback == 'd1) && (sent_writeback_beats == writeback_required_beats) && axi_write_master_resp_valid ? FTE_FSM_NSB_RESP
 
-                        // Sending last beat, more nodeslots to go
-                        : (sent_writeback_beats == writeback_required_beats) && axi_write_master_resp_valid ? FTE_FSM_SHIFT
+                        // Sending last beat, more nodeslots to go - or row not valid, shift in next row
+                        : ((sent_writeback_beats == writeback_required_beats | !valid_row[0]) && axi_write_master_resp_valid) ? FTE_FSM_SHIFT
                         : FTE_FSM_WRITEBACK_RESP;
         end
 
@@ -411,7 +429,6 @@ always_comb begin
     // Bias and activation after multiplication finished
     bias_valid       = (fte_state == FTE_FSM_BIAS);
     activation_valid = (fte_state == FTE_FSM_ACTIVATION);
-    shift_sys_module = (fte_state == FTE_FSM_SHIFT);
 end
 
 // Buffering Logic
@@ -452,23 +469,23 @@ count_ones #(
 always_comb begin
     out_features_required_bytes = layer_config_out_features_count * 4; // 4 bytes per feature
     out_features_required_bytes = {out_features_required_bytes[$clog2(top_pkg::MAX_FEATURE_COUNT * 4) - 1 : 6], 6'd0} + (out_features_required_bytes[5:0] ? 'd64 : 1'b0); // nearest multiple of 64
-    // Div feautre count by 16, round up
+    // Div feautre count by 16, round up - *float32/512 - paramterize for different data widths
     writeback_required_beats = (layer_config_out_features_count >> 4) + (layer_config_out_features_count[3:0] ? 1'b1 : 1'b0);
 
     // Request
-    axi_write_master_req_valid = (fte_state == FTE_FSM_WRITEBACK_REQ);
+    axi_write_master_req_valid = (fte_state == FTE_FSM_WRITEBACK_REQ && valid_row[0]); ;
     axi_write_master_req_start_address = {layer_config_out_features_address_msb_value, layer_config_out_features_address_lsb_value}
                                             + sys_module_node_id_snapshot[0] * out_features_required_bytes;
 
     axi_write_master_req_len = writeback_required_beats - 1'b1;
 
+
     // Data
-    axi_write_master_data_valid = (fte_state == FTE_FSM_WRITEBACK_RESP);
-    axi_write_master_data = {sys_module_pe_acc [SYS_MODULES_PER_BEAT*sent_writeback_beats + 'd3][0],
-                            sys_module_pe_acc  [SYS_MODULES_PER_BEAT*sent_writeback_beats + 'd2][0],
-                            sys_module_pe_acc  [SYS_MODULES_PER_BEAT*sent_writeback_beats + 'd1][0],
-                            sys_module_pe_acc  [SYS_MODULES_PER_BEAT*sent_writeback_beats + 'd0][0]
-                        };
+    axi_write_master_data_valid = (fte_state == FTE_FSM_WRITEBACK_RESP) & valid_row[0];
+    
+    //Temp - fix order of features in prefetcher 
+    axi_write_master_data_unreversed = sys_module_pe_acc_row0[sent_writeback_beats*SYS_MODULES_PER_BEAT +: SYS_MODULES_PER_BEAT];
+    axi_write_master_data = reverse_float_order(sys_module_pe_acc_row0[sent_writeback_beats*SYS_MODULES_PER_BEAT +: SYS_MODULES_PER_BEAT]);
 
     // Response
     axi_write_master_resp_ready = (fte_state == FTE_FSM_WRITEBACK_RESP);
@@ -494,7 +511,7 @@ always_ff @(posedge core_clk or negedge resetn) begin
         sent_writeback_beats <= sent_writeback_beats + 1'b1;
 
     // Accepting write response
-    end else if (fte_state == FTE_FSM_WRITEBACK_RESP && axi_write_master_resp_valid && sent_writeback_beats == writeback_required_beats) begin
+    end else if (valid_row[0] && fte_state == FTE_FSM_WRITEBACK_RESP && axi_write_master_resp_valid && sent_writeback_beats == writeback_required_beats) begin
         nodeslots_to_writeback <= nodeslots_to_writeback - 1'b1;
     end
 end
@@ -536,5 +553,25 @@ always_ff @(posedge core_clk or negedge resetn) begin
         last_weight_resp_received <= '1;
     end
 end
+
+assign valid_row[MATRIX_N] = 0;
+
+//Integrate to snapshot logic
+for (genvar k = 0; k < MATRIX_N ; k++) begin
+    always_ff @(posedge core_clk or negedge resetn) begin
+        if(!resetn) begin
+            valid_row[k] = 0;             //[0]th column, jth row
+        end
+        else if(fte_state == FTE_FSM_SHIFT)begin
+            valid_row[k] = valid_row[k+1];
+        end
+        else if(fte_state == FTE_FSM_REQ_WC)begin
+            valid_row[k] = busy_aggregation_slots_snapshot[k];
+        end 
+
+    end
+end 
+
+
 
 endmodule

--- a/hw/ip/transformation_engine/rtl/feature_transformation_engine.sv
+++ b/hw/ip/transformation_engine/rtl/feature_transformation_engine.sv
@@ -173,6 +173,8 @@ logic [top_pkg::PRECISION_COUNT-1:0] [7:0]    transformation_core_axi_write_mast
 logic [top_pkg::PRECISION_COUNT-1:0]          transformation_core_axi_write_master_pop;
 logic [top_pkg::PRECISION_COUNT-1:0]          transformation_core_axi_write_master_data_valid;
 logic [top_pkg::PRECISION_COUNT-1:0] [511:0]  transformation_core_axi_write_master_data;
+logic [top_pkg::PRECISION_COUNT-1:0] [511:0]  transformation_core_axi_write_master_data_unreversed;
+
 logic [top_pkg::PRECISION_COUNT-1:0]          transformation_core_axi_write_master_resp_valid;
 logic [top_pkg::PRECISION_COUNT-1:0]          transformation_core_axi_write_master_resp_ready;
 
@@ -282,6 +284,8 @@ for (genvar precision = 0; precision < top_pkg::PRECISION_COUNT; precision++) be
         .axi_write_master_pop                                       (transformation_core_axi_write_master_pop               [precision]),
         .axi_write_master_data_valid                                (transformation_core_axi_write_master_data_valid        [precision]),
         .axi_write_master_data                                      (transformation_core_axi_write_master_data              [precision]),
+        
+        .axi_write_master_data_unreversed                           (transformation_core_axi_write_master_data_unreversed   [precision]), //Temp
 
         .axi_write_master_resp_valid                                (transformation_core_axi_write_master_resp_valid        [precision]),
         .axi_write_master_resp_ready                                (transformation_core_axi_write_master_resp_ready        [precision]),

--- a/hw/sim/sources.mk
+++ b/hw/sim/sources.mk
@@ -6,7 +6,6 @@ VERILOG_INCLUDE_DIRS = \
 	$(WORKAREA)/hw/build/regbanks/node_scoreboard_regbank \
 	$(WORKAREA)/hw/build/regbanks/prefetcher_regbank \
 	/mnt/applications/Xilinx/19.2/Vivado/2019.2/data/xilinx_vip/include
-
 # Xilinx IP
 VERILOG_SOURCES = \
 	$(WORKAREA)/hw/sim/glbl.v \
@@ -79,11 +78,14 @@ VERILOG_SOURCES += \
 	$(WORKAREA)/hw/build/ip/lib/arithmetic/fixed_point_mac.sv \
 	$(WORKAREA)/hw/build/ip/lib/arithmetic/float_mac.sv \
 	$(WORKAREA)/hw/build/ip/lib/arithmetic/mac.sv \
+	$(WORKAREA)/hw/build/ip/lib/arithmetic/fp_add.sv \
+	$(WORKAREA)/hw/build/ip/lib/arithmetic/fp_mult.sv \
 	$(WORKAREA)/hw/build/ip/lib/buffers/bram_fifo.sv \
 	$(WORKAREA)/hw/build/ip/lib/buffers/hybrid_buffer/hybrid_buffer.sv \
 	$(WORKAREA)/hw/build/ip/lib/buffers/hybrid_buffer/hybrid_buffer_driver.sv \
 	$(WORKAREA)/hw/build/ip/lib/buffers/hybrid_buffer/hybrid_buffer_slot.sv \
 	$(WORKAREA)/hw/build/ip/lib/buffers/ultraram_fifo.sv \
+	$(WORKAREA)/hw/build/ip/lib/buffers/buffer_bram.sv \
 	$(WORKAREA)/hw/build/ip/lib/arithmetic/aggregators/passthrough_aggregator.sv \
 	$(WORKAREA)/hw/build/ip/lib/systolic_modules/activation_core.sv \
 	$(WORKAREA)/hw/build/ip/lib/systolic_modules/processing_element.sv \


### PR DESCRIPTION
### Bugfixes
- Issue in weight bank due to empty weight FIFOs being set to full and dumping undefined values when reset (https://github.com/alexfrater/agile/commit/dfabf3484eee6bd79e95055c2efef4b1807c9cae)
- FP modules outputting undefined signals (https://github.com/alexfrater/agile/commit/d50adb44259584a6eb4fc2760f2c2f93dc27e3b1)
- FTE writeback logic not fuctioning correctly (https://github.com/alexfrater/agile/commit/239440c9b216b1211353c015d9d7523257b6abc8)
- Bug generating 4 meshes(https://github.com/alexfrater/agile/commit/91c17d0707d9ce5d89bb446dcfa353dad63289dc)
- Bug generating 4 meshes 2(https://github.com/alexfrater/agile/commit/4e9905eb643984511f0a9473b5f65630daf9eb2c)
- Aggregation feature write count - enable feature counts of arbitrary length(https://github.com/alexfrater/agile/commit/5b8f72b1cd07ef6e1482cd6c18fddc90e7e2061a)
- Correct feature input order(https://github.com/alexfrater/agile/commit/31b372d9648e7d474ffd63d3b3bca4467d013eaf)
- Allow writeback of non fully populated fte(https://github.com/alexfrater/agile/commit/f8227a7098911fb34b45169d7462113100e1f819)
- Fast multiplication bug fix(https://github.com/alexfrater/agile/commit/aaa43006dc8c6ab4f0b84190dd3c2da58158c3f6)
- Bug fix buffer slot reset after transform(https://github.com/alexfrater/agile/commit/7b80cb2636fe90cf02dfd44dcfd42a28a1f4889a)
- Fix bug last row of FTE not reset(https://github.com/alexfrater/agile/commit/5b99d670c3464ce4dd70175f90abb4556d700f08)
- Backpressure enabled on agc feature aggregator and bug fix valid signal feature aggregator(https://github.com/alexfrater/agile/commit/36fadb42a953cb01029c1e591c39336c80dbafed)
- Reset row fifos between layers (MLP testbench passed)(https://github.com/alexfrater/agile/commit/3fa3e8364a1569f1578cc31e8182bb95105b59eb)

Note: Not verified with testbench as the bugfixes were picked from working repo to add as a standalone PR